### PR TITLE
make CL-ENVIRONMENTS build on AllegroCL

### DIFF
--- a/src/other/allegro.lisp
+++ b/src/other/allegro.lisp
@@ -24,8 +24,10 @@
 ;;;; OTHER DEALINGS IN THE SOFTWARE.
 
 (defpackage :cl-environments
-  (:use :common-lisp
-	:sys)
+  (:use :common-lisp)
+
+  (:import-from :cl-environments.util
+                :reexport-all-symbols)
 
   (:shadow :variable-information
 	   :function-information


### PR DESCRIPTION
Import used symbol from :CL-ENVIRONMENTS.UTIL. Also, remove :SYS from the use list, which as far as I can tell doesn't designate a package.