### PR TITLE
Qualify TEST-OP with ASDF: to make Clisp happy.

### DIFF
--- a/cl-environments.asd
+++ b/cl-environments.asd
@@ -122,5 +122,6 @@
 		   (:file "define-declaration")
 		   (:file "augment-environment"))))))
 
-  :perform (test-op (o s)
-		    (uiop:symbol-call :cl-environments.test.cltl2 :test-cl-environments)))
+  :perform (asdf:test-op (o s)
+		         (uiop:symbol-call :cl-environments.test.cltl2
+                                           :test-cl-environments)))


### PR DESCRIPTION
Without this change, loading cl-environments.asd on Clisp fails with
"FIND-CLASS: TEST-OP does not name a class".