### PR TITLE
PACKAGE-LOCK-VIOLATION errors on SBCL: Don't declare a var to be special if it is special in null-env

### DIFF
--- a/src/other/sbcl.lisp
+++ b/src/other/sbcl.lisp
@@ -185,7 +185,8 @@
 		(remove-if #'symbolp things))))
 
            (decl-special-var (var)
-             (when (eq :special (variable-information var env))
+             (when (and (not (eq :special (variable-information var)))
+                        (eq :special (variable-information var env)))
                `((special ,var)))))
 
     (let ((decl-vars (set-difference (mappend #'extract-var declare)


### PR DESCRIPTION
Without this, walking forms that expand into forms that bind or declare variables in locked packages can lead to package lock violation. For example, the following leads to an error which seems like package lock is being violated:

```lisp
(cl-form-types:nth-form-type `(handler-case
                                  (+ 1 2)
                                (error (c)
                                  (declare (ignore c))
                                  (format t "Oops~%")))
                             nil)
```

```lisp
NIL fell through ECASE expression.
Wanted one of (:COMPILE :EVAL).
   [Condition of type SB-KERNEL:CASE-FAILURE]

Restarts:
 0: [IGNORE-ALL] Ignore all package locks in the context of this operation.
 1: [UNLOCK-PACKAGE] Unlock the package.
 2: [RETURN-DEFAULT-TYPE] CL-FORM-TYPES:RETURN-DEFAULT-TYPE
 3: [RETURN-DEFAULT-TYPE] CL-FORM-TYPES:RETURN-DEFAULT-TYPE
 4: [RETRY] Retry SLIME REPL evaluation request.
 5: [*ABORT] Return to SLIME's top level.
 --more--

Backtrace:
  0: ((FLET "H0" :IN SB-KERNEL:PROGRAM-ASSERT-SYMBOL-HOME-PACKAGE-UNLOCKED) #<SYMBOL-PACKAGE-LOCKED-ERROR "declaring ~A special" {1008B08C43}>)
  1: (SB-KERNEL::%SIGNAL #<SYMBOL-PACKAGE-LOCKED-ERROR "declaring ~A special" {1008B08C43}>)
  2: (CERROR "Ignore the package lock." SYMBOL-PACKAGE-LOCKED-ERROR :PACKAGE #<PACKAGE "SB-KERNEL"> :FORMAT-CONTROL "declaring ~A special" :FORMAT-ARGUMENTS (SB-KERNEL:*HANDLER-CLUSTERS*) :SYMBOL SB-KERNEL..
  3: (PACKAGE-LOCK-VIOLATION #<PACKAGE "SB-KERNEL"> :SYMBOL SB-KERNEL:*HANDLER-CLUSTERS* :FORMAT-CONTROL "declaring ~A special" :FORMAT-ARGUMENTS (SB-KERNEL:*HANDLER-CLUSTERS*))
  4: (SB-KERNEL:ASSERT-SYMBOL-HOME-PACKAGE-UNLOCKED SB-KERNEL:*HANDLER-CLUSTERS* "declaring ~A special")
```

---

I'm assuming that there is no way to declare a variable defined using `defparameter` and `defvar` to be not special, unless it is uninterned, and that's why the fix should be okay.