### PR TITLE
In AUGMENT-ENVIRONMENT on SBCL, use second element of dynamic-extent

### DIFF
--- a/src/other/sbcl.lisp
+++ b/src/other/sbcl.lisp
@@ -191,7 +191,7 @@
 		(remove-if #'symbolp things))
 
 	       ((list* 'dynamic-extent things)
-		(remove-if #'symbolp things))))
+		(mapcar #'second (remove-if #'symbolp things)))))
 
            (decl-special-var (var)
              (when (eq :special (variable-information var env))


### PR DESCRIPTION
On SBCL 2.3.11, `(cl-environments:augment-environment nil :declare '((dynamic-extent (function foo))))` leads to the following error:

```lisp
The value
  #'FOO
is not of type
  (OR SYMBOL (AND CONS (SATISFIES SB-INT:LEGAL-FUN-NAME-P)))
when setting slot SB-C::%SOURCE-NAME of structure SB-C::CLAMBDA
   [Condition of type TYPE-ERROR]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] abort thread (#<THREAD tid=50144 "repl-thread" RUNNING {1001460003}>)

Backtrace:
  0: (SB-C::MAKE-CLAMBDA :NUMBER NIL :%SOURCE-NAME (FUNCTION FOO) :TYPE NIL :DEFINED-TYPE #<SB-KERNEL:NAMED-TYPE T> :WHERE-FROM :DEFINED :REFS NIL :EVER-USED NIL :DYNAMIC-EXTENT NIL :INFO NIL :%DEBUG-NAME ..
  1: (SB-CLTL2:AUGMENT-ENVIRONMENT #<SB-KERNEL:LEXENV {10082E7A63}> :VARIABLE NIL :SYMBOL-MACRO NIL :FUNCTION ((FUNCTION FOO)) :MACRO NIL :DECLARE ((DYNAMIC-EXTENT (FUNCTION FOO))))
```

The current PR fixes this issue.

[This CLHS issue](https://www.lispworks.com/documentation/HyperSpec/Issues/iss141_w.htm) also specifies that function arguments to dynamic-extent are to be given as `(dynamic-extent (function ...))`.